### PR TITLE
Encode images as PNG files instead

### DIFF
--- a/src/main/java/me/ramidzkh/fabrishot/Fabrishot.java
+++ b/src/main/java/me/ramidzkh/fabrishot/Fabrishot.java
@@ -102,7 +102,7 @@ public class Fabrishot {
         Path file;
 
         do {
-            file = dir.resolve(String.format("huge_%s_%04d.tga", DATE_FORMAT.format(new Date()), i++));
+            file = dir.resolve(String.format("huge_%s_%04d.png", DATE_FORMAT.format(new Date()), i++));
         } while (Files.exists(file));
 
         return file;

--- a/src/main/java/me/ramidzkh/fabrishot/MinecraftInterface.java
+++ b/src/main/java/me/ramidzkh/fabrishot/MinecraftInterface.java
@@ -56,33 +56,28 @@ public interface MinecraftInterface {
         return CLIENT.getWindow().getHeight();
     }
 
-    static void writeFramebuffer(ByteBuffer pixelBuffer, boolean flipColors, boolean flipLines) {
-        GL11.glReadPixels(0, 0, getDisplayWidth(), getDisplayHeight(), flipColors ? GL12.GL_BGR : GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, pixelBuffer);
+    static void writeFramebuffer(ByteBuffer pb, int bpp, boolean flip) {
+        GL11.glReadPixels(0, 0, getDisplayWidth(), getDisplayHeight(), GL11.GL_RGB, GL11.GL_UNSIGNED_BYTE, pb);
 
-        if (!flipLines) {
-            return;
-        }
-
-        final int BPP = 3; // bytes per pixel
-        byte[] line1 = new byte[getDisplayWidth() * BPP];
-        byte[] line2 = new byte[getDisplayWidth() * BPP];
+        byte[] line1 = new byte[getDisplayWidth() * bpp];
+        byte[] line2 = new byte[getDisplayWidth() * bpp];
 
         // flip buffer vertically
         for (int i = 0; i < getDisplayHeight() / 2; i++) {
-            int ofs1 = i * getDisplayWidth() * BPP;
-            int ofs2 = (getDisplayHeight() - i - 1) * getDisplayWidth() * BPP;
+            int ofs1 = i * getDisplayWidth() * bpp;
+            int ofs2 = (getDisplayHeight() - i - 1) * getDisplayWidth() * bpp;
 
             // read lines
-            pixelBuffer.position(ofs1);
-            pixelBuffer.get(line1);
-            pixelBuffer.position(ofs2);
-            pixelBuffer.get(line2);
+            pb.position(ofs1);
+            pb.get(line1);
+            pb.position(ofs2);
+            pb.get(line2);
 
             // write lines at swapped positions
-            pixelBuffer.position(ofs2);
-            pixelBuffer.put(line1);
-            pixelBuffer.position(ofs1);
-            pixelBuffer.put(line2);
+            pb.position(ofs2);
+            pb.put(line1);
+            pb.position(ofs1);
+            pb.put(line2);
         }
     }
 }

--- a/src/main/java/me/ramidzkh/fabrishot/capture/FramebufferCapturer.java
+++ b/src/main/java/me/ramidzkh/fabrishot/capture/FramebufferCapturer.java
@@ -30,42 +30,27 @@ import org.lwjgl.opengl.GL11;
 import java.nio.ByteBuffer;
 
 public class FramebufferCapturer {
-
-    private static final int BPP = 3; // bytes per pixel
+    private static final int COMPONENT_COUNT = 3; // RGB
+    private static final int BYTES_PER_PIXEL = COMPONENT_COUNT; // 8 bits per component
 
     private final ByteBuffer bb;
     private final Dimension dim;
-    private boolean flipColors = false;
-    private boolean flipLines = false;
 
     public FramebufferCapturer() {
         dim = getCurrentDimension();
-        bb = ByteBuffer.allocateDirect(dim.width * dim.height * BPP);
-    }
-
-    public boolean isFlipColors() {
-        return flipColors;
-    }
-
-    public void setFlipColors(boolean flipColors) {
-        this.flipColors = flipColors;
-    }
-
-    public boolean isFlipLines() {
-        return flipLines;
-    }
-
-    public void setFlipLines(boolean flipLines) {
-        this.flipLines = flipLines;
+        bb = ByteBuffer.allocateDirect(dim.width * dim.height * BYTES_PER_PIXEL);
     }
 
     public int getBytesPerPixel() {
-        return BPP;
+        return BYTES_PER_PIXEL;
     }
 
-    public ByteBuffer getByteBuffer() {
-        bb.rewind();
-        return bb.duplicate();
+    public int getChannelCount() {
+        return COMPONENT_COUNT;
+    }
+
+    public ByteBuffer getDataBuffer() {
+        return bb;
     }
 
     public Dimension getCaptureDimension() {
@@ -76,7 +61,7 @@ public class FramebufferCapturer {
         return new Dimension(MinecraftInterface.getDisplayWidth(), MinecraftInterface.getDisplayHeight());
     }
 
-    public void capture() {
+    public void capture(boolean flip) {
         // check if the dimensions are still the same
         Dimension dim1 = getCurrentDimension();
         Dimension dim2 = getCaptureDimension();
@@ -91,6 +76,8 @@ public class FramebufferCapturer {
         GL11.glPixelStorei(GL11.GL_PACK_ALIGNMENT, 1);
         GL11.glPixelStorei(GL11.GL_UNPACK_ALIGNMENT, 1);
 
-        MinecraftInterface.writeFramebuffer(bb, flipColors, flipLines);
+        MinecraftInterface.writeFramebuffer(bb, BYTES_PER_PIXEL, flip);
+
+        bb.rewind();
     }
 }


### PR DESCRIPTION
Uncompressed TGA files are frighteningly large, have limited support, and require users to typically re-encode them to PNG or something else down the line anyways.

Since Minecraft is already shipping the STB artifacts from LWJGL, we can simply use its PNG encoder instead. While encoding a PNG file takes a bit more time (though still basically "instant" on my machine), the file size is a fraction of what it's normally be (usually ~3 MB instead of ~23 MB.)

This also allows the code responsible for manually writing out a TGA header and performing the color-flip modifications to be eliminated.