### PR TITLE
Add option for vanilla filename format

### DIFF
--- a/src/main/java/me/ramidzkh/fabrishot/Fabrishot.java
+++ b/src/main/java/me/ramidzkh/fabrishot/Fabrishot.java
@@ -25,6 +25,7 @@
 package me.ramidzkh.fabrishot;
 
 import me.ramidzkh.fabrishot.capture.CaptureTask;
+import me.ramidzkh.fabrishot.config.Config;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.options.KeyBinding;
@@ -95,15 +96,20 @@ public class Fabrishot {
         } catch (IOException ex) {
             throw new UncheckedIOException(ex);
         }
-
-        // loop though suffixes while the file exists
-        int i = 0;
+    
         Path file;
-
-        do {
-            file = dir.resolve(String.format("huge_%s_%04d.png", DATE_FORMAT.format(new Date()), i++));
-        } while (Files.exists(file));
-
+    
+        if(Config.OVERRIDE_FILENAME_FORMAT){
+            // loop though suffixes while the file exists
+            int i = 0;
+        
+            do {
+                file = dir.resolve(String.format("huge_%s_%04d.png", DATE_FORMAT.format(new Date()), i++));
+            } while (Files.exists(file));
+        }else{
+            file = dir.resolve(String.format("%s.png", DATE_FORMAT.format(new Date())));
+        }
+    
         return file;
     }
 }

--- a/src/main/java/me/ramidzkh/fabrishot/Fabrishot.java
+++ b/src/main/java/me/ramidzkh/fabrishot/Fabrishot.java
@@ -99,7 +99,7 @@ public class Fabrishot {
     
         Path file;
     
-        if(Config.OVERRIDE_FILENAME_FORMAT){
+        if(Config.CUSTOM_FILENAME_FORMAT){
             // loop though suffixes while the file exists
             int i = 0;
         

--- a/src/main/java/me/ramidzkh/fabrishot/config/ClothConfigBridge.java
+++ b/src/main/java/me/ramidzkh/fabrishot/config/ClothConfigBridge.java
@@ -48,7 +48,7 @@ public class ClothConfigBridge implements ConfigScreenFactory<Screen> {
                 .setSavingRunnable(() -> {
                     Properties properties = new Properties();
                     properties.put("override_screenshot_key", String.valueOf(Config.OVERRIDE_SCREENSHOT_KEY));
-                    properties.put("override_filename_format", String.valueOf(Config.OVERRIDE_FILENAME_FORMAT));
+                    properties.put("custom_filename_format", String.valueOf(Config.CUSTOM_FILENAME_FORMAT));
                     properties.put("width", String.valueOf(Config.CAPTURE_WIDTH));
                     properties.put("height", String.valueOf(Config.CAPTURE_HEIGHT));
 
@@ -67,9 +67,9 @@ public class ClothConfigBridge implements ConfigScreenFactory<Screen> {
                 .setSaveConsumer(b -> Config.OVERRIDE_SCREENSHOT_KEY = b)
                 .build());
     
-        category.addEntry(entryBuilder.startBooleanToggle(new TranslatableText("fabrishot.config.override_filename_format"), Config.OVERRIDE_FILENAME_FORMAT)
+        category.addEntry(entryBuilder.startBooleanToggle(new TranslatableText("fabrishot.config.custom_filename_format"), Config.CUSTOM_FILENAME_FORMAT)
                 .setDefaultValue(true)
-                .setSaveConsumer(b -> Config.OVERRIDE_FILENAME_FORMAT = b)
+                .setSaveConsumer(b -> Config.CUSTOM_FILENAME_FORMAT = b)
                 .build());
 
         category.addEntry(entryBuilder.startIntField(new TranslatableText("fabrishot.config.width"), Config.CAPTURE_WIDTH)

--- a/src/main/java/me/ramidzkh/fabrishot/config/ClothConfigBridge.java
+++ b/src/main/java/me/ramidzkh/fabrishot/config/ClothConfigBridge.java
@@ -48,6 +48,7 @@ public class ClothConfigBridge implements ConfigScreenFactory<Screen> {
                 .setSavingRunnable(() -> {
                     Properties properties = new Properties();
                     properties.put("override_screenshot_key", String.valueOf(Config.OVERRIDE_SCREENSHOT_KEY));
+                    properties.put("override_filename_format", String.valueOf(Config.OVERRIDE_FILENAME_FORMAT));
                     properties.put("width", String.valueOf(Config.CAPTURE_WIDTH));
                     properties.put("height", String.valueOf(Config.CAPTURE_HEIGHT));
 
@@ -64,6 +65,11 @@ public class ClothConfigBridge implements ConfigScreenFactory<Screen> {
         category.addEntry(entryBuilder.startBooleanToggle(new TranslatableText("fabrishot.config.override_screenshot_key"), Config.OVERRIDE_SCREENSHOT_KEY)
                 .setDefaultValue(false)
                 .setSaveConsumer(b -> Config.OVERRIDE_SCREENSHOT_KEY = b)
+                .build());
+    
+        category.addEntry(entryBuilder.startBooleanToggle(new TranslatableText("fabrishot.config.override_filename_format"), Config.OVERRIDE_FILENAME_FORMAT)
+                .setDefaultValue(true)
+                .setSaveConsumer(b -> Config.OVERRIDE_FILENAME_FORMAT = b)
                 .build());
 
         category.addEntry(entryBuilder.startIntField(new TranslatableText("fabrishot.config.width"), Config.CAPTURE_WIDTH)

--- a/src/main/java/me/ramidzkh/fabrishot/config/Config.java
+++ b/src/main/java/me/ramidzkh/fabrishot/config/Config.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 public class Config {
 
     public static boolean OVERRIDE_SCREENSHOT_KEY = false;
+    public static boolean OVERRIDE_FILENAME_FORMAT = true;
     public static int CAPTURE_WIDTH = 3840;
     public static int CAPTURE_HEIGHT = 2160;
 
@@ -42,6 +43,7 @@ public class Config {
             properties.load(reader);
 
             Config.OVERRIDE_SCREENSHOT_KEY = Boolean.parseBoolean(properties.getProperty("override_screenshot_key"));
+            Config.OVERRIDE_FILENAME_FORMAT = Boolean.parseBoolean(properties.getProperty("override_filename_format"));
             Config.CAPTURE_WIDTH = Integer.parseInt(properties.getProperty("width"));
             Config.CAPTURE_HEIGHT = Integer.parseInt(properties.getProperty("height"));
         } catch (Exception ignored) {

--- a/src/main/java/me/ramidzkh/fabrishot/config/Config.java
+++ b/src/main/java/me/ramidzkh/fabrishot/config/Config.java
@@ -33,7 +33,7 @@ import java.util.Properties;
 public class Config {
 
     public static boolean OVERRIDE_SCREENSHOT_KEY = false;
-    public static boolean OVERRIDE_FILENAME_FORMAT = true;
+    public static boolean CUSTOM_FILENAME_FORMAT = true;
     public static int CAPTURE_WIDTH = 3840;
     public static int CAPTURE_HEIGHT = 2160;
 
@@ -43,7 +43,7 @@ public class Config {
             properties.load(reader);
 
             Config.OVERRIDE_SCREENSHOT_KEY = Boolean.parseBoolean(properties.getProperty("override_screenshot_key"));
-            Config.OVERRIDE_FILENAME_FORMAT = Boolean.parseBoolean(properties.getProperty("override_filename_format"));
+            Config.CUSTOM_FILENAME_FORMAT = Boolean.parseBoolean(properties.getProperty("custom_filename_format"));
             Config.CAPTURE_WIDTH = Integer.parseInt(properties.getProperty("width"));
             Config.CAPTURE_HEIGHT = Integer.parseInt(properties.getProperty("height"));
         } catch (Exception ignored) {

--- a/src/main/resources/assets/fabrishot/lang/de_de.json
+++ b/src/main/resources/assets/fabrishot/lang/de_de.json
@@ -2,6 +2,7 @@
   "fabrishot.config.title": "Fabrishot",
   "fabrishot.config.category": "Screenshot Größe",
   "fabrishot.config.override_screenshot_key": "Normalen Screenshot überschreiben",
+  "fabrishot.config.custom_filename_format": "Andere Dateinamenformat benutzen",
   "fabrishot.config.width": "Screenshot Breite",
   "fabrishot.config.height": "Screenshot Höhe",
   "key.fabrishot.screenshot": "Großen Screenshot aufnehmen"

--- a/src/main/resources/assets/fabrishot/lang/en_us.json
+++ b/src/main/resources/assets/fabrishot/lang/en_us.json
@@ -2,7 +2,7 @@
   "fabrishot.config.title": "Fabrishot",
   "fabrishot.config.category": "Screenshot dimensions",
   "fabrishot.config.override_screenshot_key": "Override normal screenshot with Fabrishot",
-  "fabrishot.config.custom_filename_format": "Prepend 'huge' and append a 4-digit number to the filename",
+  "fabrishot.config.custom_filename_format": "Use different filename format",
   "fabrishot.config.width": "Screenshot width",
   "fabrishot.config.height": "Screenshot height",
   "key.fabrishot.screenshot": "Take large screenshot"

--- a/src/main/resources/assets/fabrishot/lang/en_us.json
+++ b/src/main/resources/assets/fabrishot/lang/en_us.json
@@ -2,6 +2,7 @@
   "fabrishot.config.title": "Fabrishot",
   "fabrishot.config.category": "Screenshot dimensions",
   "fabrishot.config.override_screenshot_key": "Override normal screenshot with Fabrishot",
+  "fabrishot.config.override_filename_format": "Prepend 'huge' and append a 4-digit number to the filename",
   "fabrishot.config.width": "Screenshot width",
   "fabrishot.config.height": "Screenshot height",
   "key.fabrishot.screenshot": "Take large screenshot"

--- a/src/main/resources/assets/fabrishot/lang/en_us.json
+++ b/src/main/resources/assets/fabrishot/lang/en_us.json
@@ -2,7 +2,7 @@
   "fabrishot.config.title": "Fabrishot",
   "fabrishot.config.category": "Screenshot dimensions",
   "fabrishot.config.override_screenshot_key": "Override normal screenshot with Fabrishot",
-  "fabrishot.config.override_filename_format": "Prepend 'huge' and append a 4-digit number to the filename",
+  "fabrishot.config.custom_filename_format": "Prepend 'huge' and append a 4-digit number to the filename",
   "fabrishot.config.width": "Screenshot width",
   "fabrishot.config.height": "Screenshot height",
   "key.fabrishot.screenshot": "Take large screenshot"


### PR DESCRIPTION
I personally don't like having my huge screenshots named differently than my vanilla ones, maybe others do as well.
Did this for myself, but figured I'd do a pull request, see whether you want this.

Although I'm not German, I think my German translation works. I don't know anything about the other languages, so I left those alone.