### PR TITLE
Use new Mod Menu package and revert to normal Terraformers maven

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ version = "1.5.2"
 repositories {
     maven {
         name = "TerraformersMC"
-        url = uri("https://maven.quiltmc.org/repository/release/")
+        url = uri("https://maven.terraformersmc.com")
 
         content {
             includeGroup("com.terraformersmc")
@@ -32,7 +32,7 @@ dependencies {
     modImplementation("net.fabricmc", "fabric-loader", "0.11.6")
 
     modImplementation("net.fabricmc.fabric-api", "fabric-api", "0.36.1+1.17")
-    modImplementation("com.terraformersmc", "modmenu", "v2.0.2+1.17.2035ad2")
+    modImplementation("com.terraformersmc", "modmenu", "2.0.13")
     modImplementation("me.shedaniel.cloth", "cloth-config-fabric", "5.0.34")
 }
 

--- a/src/main/java/me/ramidzkh/fabrishot/config/ClothConfigBridge.java
+++ b/src/main/java/me/ramidzkh/fabrishot/config/ClothConfigBridge.java
@@ -25,7 +25,7 @@
 package me.ramidzkh.fabrishot.config;
 
 import com.mojang.blaze3d.systems.RenderSystem;
-import io.github.prospector.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
 import me.ramidzkh.fabrishot.Fabrishot;
 import me.shedaniel.clothconfig2.api.ConfigBuilder;
 import me.shedaniel.clothconfig2.api.ConfigCategory;

--- a/src/main/java/me/ramidzkh/fabrishot/config/ModMenuBridge.java
+++ b/src/main/java/me/ramidzkh/fabrishot/config/ModMenuBridge.java
@@ -24,8 +24,8 @@
 
 package me.ramidzkh.fabrishot.config;
 
-import io.github.prospector.modmenu.api.ConfigScreenFactory;
-import io.github.prospector.modmenu.api.ModMenuApi;
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
 import net.fabricmc.loader.api.FabricLoader;
 
 public class ModMenuBridge implements ModMenuApi {


### PR DESCRIPTION
On 1.18 snapshots, the package name causes Mod Menu integration to not work, because the package no longer exists. (The config as well as the mod as a whole work fine on 1.18 snapshots without changes other than this.)

Also, the Terraformers Maven is stable now, so I've reverted to the normal one.