### PR TITLE
Calculate display size based on framebuffer size

### DIFF
--- a/src/main/java/me/ramidzkh/fabrishot/MinecraftInterface.java
+++ b/src/main/java/me/ramidzkh/fabrishot/MinecraftInterface.java
@@ -46,11 +46,11 @@ public interface MinecraftInterface {
     }
 
     static int getDisplayWidth() {
-        return CLIENT.getWindow().getWidth();
+        return CLIENT.getWindow().getFramebufferWidth();
     }
 
     static int getDisplayHeight() {
-        return CLIENT.getWindow().getHeight();
+        return CLIENT.getWindow().getFramebufferHeight();
     }
 
     static void writeFramebuffer(ByteBuffer pb, int bpp) {

--- a/src/main/java/me/ramidzkh/fabrishot/MinecraftInterface.java
+++ b/src/main/java/me/ramidzkh/fabrishot/MinecraftInterface.java
@@ -37,8 +37,12 @@ public interface MinecraftInterface {
     static void resize(int width, int height) {
         WindowAccessor accessor = (WindowAccessor) (Object) CLIENT.getWindow();
 
-        accessor.setWidth(width);
-        accessor.setHeight(height);
+        int windowWidth = (int) ((float) width * ((float) CLIENT.getWindow().getWidth() / getDisplayWidth()));
+        int windowHeight = (int) ((float) height * ((float) CLIENT.getWindow().getHeight() / getDisplayHeight()));
+
+        accessor.setWidth(windowWidth);
+        accessor.setHeight(windowHeight);
+
         accessor.setFramebufferWidth(width);
         accessor.setFramebufferHeight(height);
 


### PR DESCRIPTION
modified the get display functions in `MinecraftInterface.java` to return the framebuffer sizes as opposed to the window sizes. also modified the resize function to calculate new window sizes based on the ratio of the old window size to the old framebuffer size.

![image](https://github.com/user-attachments/assets/2f18c5db-b06c-4d53-8d1c-a839900a60b5)

tested on arch linux, kde plasma wayland, native system glfw through prism launcher

Closes #49