### PR TITLE
Fix RenderScale compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,15 @@ repositories {
             includeGroup("me.shedaniel.cloth")
         }
     }
+
+    maven {
+        name = "Modrinth"
+        url = uri("https://api.modrinth.com/maven")
+
+        content {
+            includeGroup("maven.modrinth")
+        }
+    }
 }
 
 dependencies {
@@ -37,6 +46,8 @@ dependencies {
     modImplementation("net.fabricmc.fabric-api:fabric-api:0.140.2+1.21.11")
     modImplementation("com.terraformersmc:modmenu:17.0.0-beta.1")
     modImplementation("me.shedaniel.cloth:cloth-config-fabric:21.11.153")
+
+    modCompileOnly("maven.modrinth:renderscale:1.3.6")
 }
 
 java {

--- a/src/main/java/me/ramidzkh/fabrishot/mixins/WindowMixin.java
+++ b/src/main/java/me/ramidzkh/fabrishot/mixins/WindowMixin.java
@@ -31,7 +31,7 @@ import me.ramidzkh.fabrishot.config.Config;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 
-@Mixin(Window.class)
+@Mixin(value = Window.class, priority = 2000)
 public class WindowMixin {
 
     @ModifyReturnValue(method = {"getScreenWidth", "getGuiScaledWidth"}, at = @At("RETURN"))

--- a/src/main/java/me/ramidzkh/fabrishot/mixins/WindowMixin.java
+++ b/src/main/java/me/ramidzkh/fabrishot/mixins/WindowMixin.java
@@ -24,29 +24,24 @@
 
 package me.ramidzkh.fabrishot.mixins;
 
+import com.llamalad7.mixinextras.injector.ModifyReturnValue;
 import com.mojang.blaze3d.platform.Window;
 import me.ramidzkh.fabrishot.Fabrishot;
 import me.ramidzkh.fabrishot.config.Config;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Window.class)
 public class WindowMixin {
 
-    @Inject(method = {"getScreenWidth", "getGuiScaledWidth"}, at = @At("RETURN"), cancellable = true)
-    private void scaleWidth(CallbackInfoReturnable<Integer> cir) {
-        if (Fabrishot.isInCapture()) {
-            cir.setReturnValue(Config.CAPTURE_WIDTH);
-        }
+    @ModifyReturnValue(method = {"getScreenWidth", "getGuiScaledWidth"}, at = @At("RETURN"))
+    private int scaleWidth(int original) {
+        return Fabrishot.isInCapture() ? Config.CAPTURE_WIDTH : original;
     }
 
-    @Inject(method = {"getScreenHeight", "getGuiScaledHeight"}, at = @At("RETURN"), cancellable = true)
-    private void scaleHeight(CallbackInfoReturnable<Integer> cir) {
-        if (Fabrishot.isInCapture()) {
-            cir.setReturnValue(Config.CAPTURE_HEIGHT);
-        }
+    @ModifyReturnValue(method = {"getScreenHeight", "getGuiScaledHeight"}, at = @At("RETURN"))
+    private int scaleHeight(int original) {
+        return Fabrishot.isInCapture() ? Config.CAPTURE_HEIGHT : original;
     }
 
     // todo: fix gui scaling (or is that needed anymore?)

--- a/src/main/java/me/ramidzkh/fabrishot/mixins/compat/renderscale/RenderscaleCommonClassMixin.java
+++ b/src/main/java/me/ramidzkh/fabrishot/mixins/compat/renderscale/RenderscaleCommonClassMixin.java
@@ -1,0 +1,16 @@
+package me.ramidzkh.fabrishot.mixins.compat.renderscale;
+
+import dev.zelo.renderscale.CommonClass;
+import me.ramidzkh.fabrishot.Fabrishot;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(CommonClass.class)
+public class RenderscaleCommonClassMixin {
+    @Inject(method = "setShouldScale", at = @At("HEAD"), cancellable = true)
+    private void fabrishot$disableScalingDuringScreenshot(boolean shouldScale, CallbackInfo ci) {
+        if (Fabrishot.isInCapture()) ci.cancel();
+    }
+}

--- a/src/main/resources/mixins.fabrishot.json
+++ b/src/main/resources/mixins.fabrishot.json
@@ -6,7 +6,8 @@
   "mixins": [
     "KeyboardMixin",
     "MinecraftClientMixin",
-    "WindowMixin"
+    "WindowMixin",
+    "compat.renderscale.RenderscaleCommonClassMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Fixes #111 

Makes use of the @ModifyReturnValue injector from MixinExtras to change window size and increases the priority of that mixin. This way the width and height of the Window are always (unless something with a priority higher than 2000) that of the fabrishot config during screenshot taking.

Also mixins into RenderScale to prevent it from doing its magical scaling and copying stuff, which led to both the normal size and full size being rendered in the screenshot